### PR TITLE
Get name of multiple levels

### DIFF
--- a/src/DataProcessingHierarchyTools.jl
+++ b/src/DataProcessingHierarchyTools.jl
@@ -216,6 +216,17 @@ function get_level_name(target_level::String, dir=pwd())
 end
 
 """
+Get the name of all requested levels
+"""
+function get_level_name(target_levels::Vector{String}, dir=pwd())
+	ll = String[]
+	for tl in target_levels
+		push!(ll, get_level_name(tl, dir))
+	end
+	joinpath(ll...)
+end
+
+"""
 Get all directories corresponding to `target_level` under the current hierarchy
 """
 function get_level_dirs(target_level::String, dir=pwd())

--- a/src/DataProcessingHierarchyTools.jl
+++ b/src/DataProcessingHierarchyTools.jl
@@ -159,7 +159,7 @@ function load(args::T) where T <: DPHDataArgs
 end
 
 """
-Returns `true` if the data described by `args` has already been 
+Returns `true` if the data described by `args` has already been
 computed
 """
 function computed(args::T) where T <: DPHDataArgs

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -56,6 +56,8 @@ dirs =["20140903/session01", "20140903/session02"]
     @test thislevel == "day"
     _name = DPHT.get_level_name("day","newWorkingMemory/Pancake/20130923")
     @test _name == "20130923"
+	_name = DPHT.get_level_name(["subject", "day"],"newWorkingMemory/Pancake/20130923")
+	@test _name == "Pancake/20130923"
     _name = DPHT.get_level_name("subject","newWorkingMemory/Pancake/20130923")
     @test _name == "Pancake"
     _pth = DPHT.process_level("session", "Pancake/20130923/session01/array01/channel001")


### PR DESCRIPTION
This allows one to get the name of more than 1 level, so that one can do

```Julia
path = "Pancake/20130923/session01/array01"
name = DataProcessingHierarchyTools.get_level_name(["subject", "day"], path)
"Pancake/20130923
```