### PR TITLE
Compat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,10 @@ before_script: # homebrew for mac
   - if [ $TRAVIS_OS_NAME = osx ]; then  rm /usr/local/include/c++; brew upgrade gcc; fi
   - if [ $TRAVIS_OS_NAME = osx ]; then brew link --overwrite gcc; fi
   - if [ $TRAVIS_OS_NAME = osx ]; then brew install hdf5; fi
+  - echo "$DEPLOY_KEY" | tr -d '\r' | ssh-add - > /dev/null
+  - mkdir -p ~/.ssh
+  - chmod 700 ~/.ssh
+  - julia -e "using Pkg; Pkg.update();pkg\"registry add git@gitlab.com:grero/NeuralCodingRegistry.jl.git\"; pkg\"registry status\""
 
 ## uncomment the following lines to override the default test script
 #script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ before_script: # homebrew for mac
   - if [ $TRAVIS_OS_NAME = osx ]; then  rm /usr/local/include/c++; brew upgrade gcc; fi
   - if [ $TRAVIS_OS_NAME = osx ]; then brew link --overwrite gcc; fi
   - if [ $TRAVIS_OS_NAME = osx ]; then brew install hdf5; fi
+  - eval $(ssh-agent -s)
   - echo "$DEPLOY_KEY" | tr -d '\r' | ssh-add - > /dev/null
   - mkdir -p ~/.ssh
   - chmod 700 ~/.ssh

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DataProcessingHierarchyTools"
 uuid = "c4d60adb-60c8-55d6-9a12-9d581dce3acf"
 author = "Roger Herikstad <roger.herikstad@gmail.com>"
-version = "0.12.0"
+version = "0.13.0"
 
 [deps]
 Glob = "c27321d9-0574-5035-807b-f59d2c89b15c"

--- a/src/types.jl
+++ b/src/types.jl
@@ -25,6 +25,7 @@ function shash(args::T, h::UInt64) where T <: DPHDataArgs
     h
 end
 
+_hash(x) =_hash(x, zero(UInt64))
 function _hash(args::T, h::UInt64) where T <: DPHDataArgs
     for f in fieldnames(T)
         x = getfield(args, f)

--- a/src/types.jl
+++ b/src/types.jl
@@ -25,6 +25,20 @@ function shash(args::T, h::UInt64) where T <: DPHDataArgs
     h
 end
 
+function _hash(args::T, h::UInt64) where T <: DPHDataArgs
+    for f in fieldnames(T)
+        x = getfield(args, f)
+        if typeof(x) <: AbstractVector
+            for _x in x
+                h = hash(_x, h)
+            end
+        elseif !((f == :version) && (x == "UNKNOWN"))
+            h = hash(x, h)
+        end
+    end
+    h
+end
+
 function shash(args::Vector{T}, h::UInt64) where T <: DPHDataArgs
     for _args in args
         h = shash(_args, h)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 module DPHTTest
 using DataProcessingHierarchyTools
 const DPHT = DataProcessingHierarchyTools
-import DataProcessingHierarchyTools:level, filename, shash
+import DataProcessingHierarchyTools:level, filename, shash, _hash
 using Test
 using LinearAlgebra
 
@@ -175,6 +175,12 @@ end
     h = shash(args)
     @test h == 0x34c727e2f750c253
     @test DPHT.filename(args) == "mydata_34c727e2f750c253.mat"
+	h2 = _hash(args)
+	if Base.VERSION < v"1.5.0"
+		@test h2 == h
+	elseif Base.VERSION < v"1.6.0"
+		@test h2 == 0x34c727e2f750c253
+	end
 end
 
 @testset "ArgsCheck" begin


### PR DESCRIPTION
Adds` _hash` function that uses `Base.hash` instead of `StableHashes.shash`, mainly for backwards testing.